### PR TITLE
Removed Serializable interface

### DIFF
--- a/lib/plugins/sfDoctrinePlugin/lib/pager/sfDoctrinePager.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/pager/sfDoctrinePager.class.php
@@ -17,7 +17,7 @@
  * @author     Jonathan H. Wage <jonwage@gmail.com>
  * @version    SVN: $Id: sfDoctrinePager.class.php 28897 2010-03-30 20:30:24Z Jonathan.Wage $
  */
-class sfDoctrinePager extends sfPager implements Serializable
+class sfDoctrinePager extends sfPager
 {
   protected
     $query             = null,
@@ -45,27 +45,15 @@ class sfDoctrinePager extends sfPager implements Serializable
     $this->tableMethodName = $tableMethodName;
   }
 
-  /**
-   * Serialize the pager object
-   *
-   * @return string $serialized
-   */
-  public function serialize()
+  public function __serialize(): array
   {
     $vars = get_object_vars($this);
     unset($vars['query']);
-    return serialize($vars);
+    return $vars;
   }
 
-  /**
-   * Unserialize a pager object
-   *
-   * @param string $serialized
-   */
-  public function unserialize($serialized)
+  public function __unserialize(array $array): void
   {
-    $array = unserialize($serialized);
-
     foreach ($array as $name => $values)
     {
       $this->$name = $values;

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Collection.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Collection.php
@@ -31,7 +31,7 @@
  * @version     $Revision: 7686 $
  * @author      Konsta Vesterinen <kvesteri@cc.hut.fi>
  */
-class Doctrine_Collection extends Doctrine_Access implements Countable, IteratorAggregate, Serializable
+class Doctrine_Collection extends Doctrine_Access implements Countable, IteratorAggregate
 {
     /**
      * @var array $data                     an array containing the records of this collection
@@ -142,12 +142,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
         $this->data = $data;
     }
 
-    /**
-     * This method is automatically called when this Doctrine_Collection is serialized
-     *
-     * @return array
-     */
-    public function serialize()
+    public function __serialize(): array
     {
         $vars = get_object_vars($this);
 
@@ -160,20 +155,13 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
 
         $vars['_table'] = $vars['_table']->getComponentName();
 
-        return serialize($vars);
+        return $vars;
     }
 
-    /**
-     * This method is automatically called everytime a Doctrine_Collection object is unserialized
-     *
-     * @return void
-     */
-    public function unserialize($serialized)
+    public function __unserialize(array $array): void
     {
         $manager    = Doctrine_Manager::getInstance();
         $connection    = $manager->getCurrentConnection();
-
-        $array = unserialize($serialized);
 
         foreach ($array as $name => $values) {
             $this->$name = $values;

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Connection.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Connection.php
@@ -53,7 +53,7 @@
  * @author      Konsta Vesterinen <kvesteri@cc.hut.fi>
  * @author      Lukas Smith <smith@pooteeweet.org> (MDB2 library)
  */
-abstract class Doctrine_Connection extends Doctrine_Configurable implements Countable, IteratorAggregate, Serializable
+abstract class Doctrine_Connection extends Doctrine_Configurable implements Countable, IteratorAggregate
 {
     /**
      * @var $dbh                                the database handler
@@ -1554,29 +1554,16 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
         return Doctrine_Lib::getConnectionAsString($this);
     }
 
-    /**
-     * Serialize. Remove database connection(pdo) since it cannot be serialized
-     *
-     * @return string $serialized
-     */
-    public function serialize()
+    public function __serialize(): array
     {
         $vars = get_object_vars($this);
         $vars['dbh'] = null;
         $vars['isConnected'] = false;
-        return serialize($vars);
+        return $vars;
     }
 
-    /**
-     * Unserialize. Recreate connection from serialized content
-     *
-     * @param string $serialized
-     * @return void
-     */
-    public function unserialize($serialized)
+    public function __unserialize(array $array): void
     {
-        $array = unserialize($serialized);
-
         foreach ($array as $name => $values) {
             $this->$name = $values;
         }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Record.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Record.php
@@ -31,7 +31,7 @@
  * @since       1.0
  * @version     $Revision: 7673 $
  */
-abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Countable, IteratorAggregate, Serializable
+abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Countable, IteratorAggregate
 {
     /**
      * STATE CONSTANTS
@@ -790,13 +790,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         }
     }
 
-    /**
-     * serialize
-     * this method is automatically called when an instance of Doctrine_Record is serialized
-     *
-     * @return string
-     */
-    public function serialize()
+    public function __serialize(): array
     {
         $event = new Doctrine_Event($this, Doctrine_Event::RECORD_SERIALIZE);
 
@@ -839,22 +833,13 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
             }
         }
 
-        $str = serialize($vars);
-
         $this->postSerialize($event);
         $this->getTable()->getRecordListener()->postSerialize($event);
 
-        return $str;
+        return $vars;
     }
 
-    /**
-     * this method is automatically called everytime an instance is unserialized
-     *
-     * @param string $serialized                Doctrine_Record as serialized string
-     * @throws Doctrine_Record_Exception        if the cleanData operation fails somehow
-     * @return void
-     */
-    public function unserialize($serialized)
+    public function __unserialize(array $array): void
     {
         $event = new Doctrine_Event($this, Doctrine_Event::RECORD_UNSERIALIZE);
 
@@ -865,8 +850,6 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
 
         $this->preUnserialize($event);
         $this->getTable()->getRecordListener()->preUnserialize($event);
-
-        $array = unserialize($serialized);
 
         foreach($array as $k => $v) {
             $this->$k = $v;

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Table.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Table.php
@@ -34,7 +34,7 @@
  * @method mixed findBy*(mixed $value) magic finders; @see __call()
  * @method mixed findOneBy*(mixed $value) magic finders; @see __call()
  */
-class Doctrine_Table extends Doctrine_Configurable implements Countable, Serializable
+class Doctrine_Table extends Doctrine_Configurable implements Countable
 {
     /**
      * @var array $data                                 temporary data which is then loaded into Doctrine_Record::$_data
@@ -2945,12 +2945,12 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
         throw new Doctrine_Table_Exception(sprintf('Unknown method %s::%s', get_class($this), $method));
     }
 
-    public function serialize()
+    public function __serialize(): array
     {
         $options = $this->_options;
         unset($options['declaringClass']);
 
-        return serialize(array(
+        return [
             $this->_identifier,
             $this->_identifierType,
             $this->_columns,
@@ -2962,13 +2962,11 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
             $options,
             $this->_invokedMethods,
             $this->_useIdentityMap,
-        ));
+        ];
     }
 
-    public function unserialize($data)
+    public function __unserialize(array $all): void
     {
-        $all = unserialize($data);
-
         $this->_identifier = $all[0];
         $this->_identifierType = $all[1];
         $this->_columns = $all[2];

--- a/lib/response/sfResponse.class.php
+++ b/lib/response/sfResponse.class.php
@@ -17,7 +17,7 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id: sfResponse.class.php 14598 2009-01-11 09:32:32Z dwhittle $
  */
-abstract class sfResponse implements Serializable
+abstract class sfResponse
 {
   protected
     $options    = array(),
@@ -144,26 +144,13 @@ abstract class sfResponse implements Serializable
     return $event->getReturnValue();
   }
 
-  /**
-   * Serializes the current instance.
-   *
-   * @return array Objects instance
-   */
-  public function serialize()
+  public function __serialize(): array
   {
-    return serialize($this->content);
+    return [$this->content];
   }
 
-  /**
-   * Unserializes a sfResponse instance.
-   *
-   * You need to inject a dispatcher after unserializing a sfResponse instance.
-   *
-   * @param string $serialized  A serialized sfResponse instance
-   *
-   */
-  public function unserialize($serialized)
+  public function __unserialize(array $array): void
   {
-    $this->content = unserialize($serialized);
+    list($this->content) = $array;
   }
 }

--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -825,17 +825,17 @@ class sfWebResponse extends sfResponse
   /**
    * @see sfResponse
    */
-  public function serialize()
+  public function __serialize(): array
   {
-    return serialize(array($this->content, $this->statusCode, $this->statusText, $this->options, $this->headerOnly, $this->headers, $this->metas, $this->httpMetas, $this->stylesheets, $this->javascripts, $this->slots));
+    return [$this->content, $this->statusCode, $this->statusText, $this->options, $this->headerOnly, $this->headers, $this->metas, $this->httpMetas, $this->stylesheets, $this->javascripts, $this->slots];
   }
 
   /**
    * @see sfResponse
    */
-  public function unserialize($serialized)
+  public function __unserialize(array $array): void
   {
-    list($this->content, $this->statusCode, $this->statusText, $this->options, $this->headerOnly, $this->headers, $this->metas, $this->httpMetas, $this->stylesheets, $this->javascripts, $this->slots) = unserialize($serialized);
+    list($this->content, $this->statusCode, $this->statusText, $this->options, $this->headerOnly, $this->headers, $this->metas, $this->httpMetas, $this->stylesheets, $this->javascripts, $this->slots) = $array;
   }
 
   /**

--- a/lib/routing/sfRoute.class.php
+++ b/lib/routing/sfRoute.class.php
@@ -16,7 +16,7 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id: sfRoute.class.php 32939 2011-08-22 13:40:06Z fabien $
  */
-class sfRoute implements Serializable
+class sfRoute
 {
   protected
     $isBound           = false,
@@ -842,17 +842,17 @@ class sfRoute implements Serializable
     }
   }
 
-  public function serialize()
+  public function __serialize(): array
   {
     // always serialize compiled routes
     $this->compile();
     // sfPatternRouting will always re-set defaultParameters, so no need to serialize them
-    return serialize(array($this->tokens, $this->defaultOptions, $this->options, $this->pattern, $this->staticPrefix, $this->regex, $this->variables, $this->defaults, $this->requirements, $this->suffix, $this->customToken));
+    return [$this->tokens, $this->defaultOptions, $this->options, $this->pattern, $this->staticPrefix, $this->regex, $this->variables, $this->defaults, $this->requirements, $this->suffix, $this->customToken];
   }
 
-  public function unserialize($data)
+  public function __unserialize(array $data): void
   {
-    list($this->tokens, $this->defaultOptions, $this->options, $this->pattern, $this->staticPrefix, $this->regex, $this->variables, $this->defaults, $this->requirements, $this->suffix, $this->customToken) = unserialize($data);
+    list($this->tokens, $this->defaultOptions, $this->options, $this->pattern, $this->staticPrefix, $this->regex, $this->variables, $this->defaults, $this->requirements, $this->suffix, $this->customToken) = $data;
     $this->compiled = true;
   }
 }

--- a/lib/util/sfNamespacedParameterHolder.class.php
+++ b/lib/util/sfNamespacedParameterHolder.class.php
@@ -359,25 +359,13 @@ class sfNamespacedParameterHolder extends sfParameterHolder
     }
   }
 
-  /**
-   * Serializes the current instance.
-   *
-   * @return array Objects instance
-   */
-  public function serialize()
+  public function __serialize(): array
   {
-    return serialize(array($this->default_namespace, $this->parameters));
+    return [$this->default_namespace, $this->parameters];
   }
 
-  /**
-   * Unserializes a sfNamespacedParameterHolder instance.
-   *
-   * @param string $serialized  A serialized sfNamespacedParameterHolder instance
-   */
-  public function unserialize($serialized)
+  public function __unserialize(array $data): void
   {
-    $data = unserialize($serialized);
-
     $this->default_namespace = $data[0];
     $this->parameters = $data[1];
   }

--- a/lib/util/sfParameterHolder.class.php
+++ b/lib/util/sfParameterHolder.class.php
@@ -21,7 +21,7 @@
  * @author     Sean Kerr <sean@code-box.org>
  * @version    SVN: $Id: sfParameterHolder.class.php 23922 2009-11-14 14:58:38Z fabien $
  */
-class sfParameterHolder implements Serializable
+class sfParameterHolder
 {
   protected $parameters = array();
 
@@ -178,23 +178,13 @@ class sfParameterHolder implements Serializable
     }
   }
 
-  /**
-   * Serializes the current instance.
-   *
-   * @return array Objects instance
-   */
-  public function serialize()
+  public function __serialize(): array
   {
-    return serialize($this->parameters);
+    return $this->parameters;
   }
 
-  /**
-   * Unserializes a sfParameterHolder instance.
-   *
-   * @param string $serialized  A serialized sfParameterHolder instance
-   */
-  public function unserialize($serialized)
+  public function __unserialize(array $array): void
   {
-    $this->parameters = unserialize($serialized);
+    $this->parameters = $array;
   }
 }

--- a/lib/validator/sfValidatorError.class.php
+++ b/lib/validator/sfValidatorError.class.php
@@ -16,7 +16,7 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id: sfValidatorError.class.php 15393 2009-02-10 12:58:49Z fabien $
  */
-class sfValidatorError extends Exception implements Serializable
+class sfValidatorError extends Exception
 {
   protected
     $validator = null,
@@ -129,18 +129,16 @@ class sfValidatorError extends Exception implements Serializable
   /**
    * Serializes the current instance.
    *
-   * We must implement the Serializable interface to overcome a problem with PDO
-   * used as a session handler.
+   * We must implement it to overcome a problem with PDO used as a session handler.
    *
    * The default serialization process serializes the exception trace, and because
    * the trace can contain a PDO instance which is not serializable, serializing won't
    * work when using PDO.
    *
-   * @return string The instance as a serialized string
    */
-  public function serialize()
+  public function __serialize(): array
   {
-    return serialize(array($this->validator, $this->arguments, $this->code, $this->message));
+    return [$this->validator, $this->arguments, $this->code, $this->message];
   }
 
   /**
@@ -149,8 +147,8 @@ class sfValidatorError extends Exception implements Serializable
    * @param string $serialized  A serialized sfValidatorError instance
    *
    */
-  public function unserialize($serialized)
+  public function __unserialize(array $array): void
   {
-    list($this->validator, $this->arguments, $this->code, $this->message) = unserialize($serialized);
+    list($this->validator, $this->arguments, $this->code, $this->message) = $array;
   }
 }

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -322,7 +322,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
     return [$this->validator, $this->arguments, $this->code, $this->message, $this->errors, $this->globalErrors, $this->namedErrors];
   }
 
-  public function __unserialize(array $array)
+  public function __unserialize(array $array): void
   {
     list($this->validator, $this->arguments, $this->code, $this->message, $this->errors, $this->globalErrors, $this->namedErrors) = $array;
   }

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -317,24 +317,13 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
     ));
   }
 
-  /**
-   * Serializes the current instance.
-   *
-   * @return string The instance as a serialized string
-   */
-  public function serialize()
+  public function __serialize(): array
   {
-    return serialize(array($this->validator, $this->arguments, $this->code, $this->message, $this->errors, $this->globalErrors, $this->namedErrors));
+    return [$this->validator, $this->arguments, $this->code, $this->message, $this->errors, $this->globalErrors, $this->namedErrors];
   }
 
-  /**
-   * Unserializes a sfValidatorError instance.
-   *
-   * @param string $serialized  A serialized sfValidatorError instance
-   *
-   */
-  public function unserialize($serialized)
+  public function __unserialize(array $array)
   {
-    list($this->validator, $this->arguments, $this->code, $this->message, $this->errors, $this->globalErrors, $this->namedErrors) = unserialize($serialized);
+    list($this->validator, $this->arguments, $this->code, $this->message, $this->errors, $this->globalErrors, $this->namedErrors) = $array;
   }
 }

--- a/lib/view/sfViewParameterHolder.class.php
+++ b/lib/view/sfViewParameterHolder.class.php
@@ -162,24 +162,14 @@ class sfViewParameterHolder extends sfParameterHolder
     $this->escapingMethod = $method;
   }
 
-  /**
-   * Serializes the current instance.
-   *
-   * @return array Objects instance
-   */
-  public function serialize()
+  public function __serialize(): array
   {
-    return serialize(array($this->getAll(), $this->escapingMethod, $this->escaping));
+    return [$this->getAll(), $this->escapingMethod, $this->escaping];
   }
 
-  /**
-   * Unserializes a sfViewParameterHolder instance.
-   *
-   * @param string $serialized The serialized instance data
-   */
-  public function unserialize($serialized)
+  public function __unserialize(array $array): void
   {
-    list($this->parameters, $escapingMethod, $escaping) = unserialize($serialized);
+    list($this->parameters, $escapingMethod, $escaping) = $array;
 
     $this->initialize(sfContext::hasInstance() ? sfContext::getInstance()->getEventDispatcher() : new sfEventDispatcher());
 


### PR DESCRIPTION
In PHP 8.1, Serializable interface is deprectated.

It would just show an E_DEPRECATED notice so we could still live with it.

But there's indeed a breaking change regarding this: the method `unserialize()` must be typed now and will throw an error otherwise:
```
public function unserialize(string $data): void;
```
So this PR proposes enterely removing Serializable interface and using the `__serialize()` and `__unserialize()` magic methods instead.

---

IMPORTANT TO NOTE:

PHP 8+ has changed the way in which internally serializes some objects such us DateTime or ArrayObject.

Things will keep working well as long as we remain in PHP7.4. But when actually migrating to PHP8+, all **stored serialized values** that main app might have will be potentially incompatible.

We need to start now a strategy to change those values to something compatible (json, or JMS Serializer).
