### PR TITLE
php8: removed usage of deprecated function each()

### DIFF
--- a/lib/plugins/sfPropelPlugin/lib/vendor/phing/lib/Zip.php
+++ b/lib/plugins/sfPropelPlugin/lib/vendor/phing/lib/Zip.php
@@ -662,12 +662,10 @@ class Archive_Zip
         $v_const_list = get_defined_constants();
   	
       	// ----- Extract error constants from all const.
-        for (reset($v_const_list);
-		     list($v_key, $v_value) = each($v_const_list);) {
-     	    if (substr($v_key, 0, strlen('ARCHIVE_ZIP_ERR_'))
-			    =='ARCHIVE_ZIP_ERR_') {
-    		    $v_error_list[$v_key] = $v_value;
-    	    }
+        foreach ($v_const_list as $v_key => $v_value) {
+            if (substr($v_key, 0, strlen('ARCHIVE_ZIP_ERR_')) == 'ARCHIVE_ZIP_ERR_') {
+                $v_error_list[$v_key] = $v_value;
+            }
         }
     
         // ----- Search the name form the code value
@@ -3232,20 +3230,20 @@ class Archive_Zip
     }
     
     // ----- Check that all the params are valid
-    for (reset($p_params); list($v_key, $v_value) = each($p_params); ) {
-    	if (!isset($p_default[$v_key])) {
+    foreach ($p_params as $v_key => $v_value) {
+      if (!isset($p_default[$v_key])) {
             $this->_errorLog(ARCHIVE_ZIP_ERR_INVALID_PARAMETER,
-			                 'Unsupported parameter with key \''.$v_key.'\'');
+                       'Unsupported parameter with key \''.$v_key.'\'');
 
             return Archive_Zip::errorCode();
-    	}
+      }
     }
 
 	// ----- Set the default values
-    for (reset($p_default); list($v_key, $v_value) = each($p_default); ) {
-    	if (!isset($p_params[$v_key])) {
-    		$p_params[$v_key] = $p_default[$v_key];
-    	}
+    foreach ($p_default as $v_key => $v_value) {
+      if (!isset($p_params[$v_key])) {
+        $p_params[$v_key] = $v_value;
+      }
     }
     
     // ----- Check specific parameters

--- a/lib/plugins/sfPropelPlugin/lib/vendor/phing/tasks/ext/pearpackage/Fileset.php
+++ b/lib/plugins/sfPropelPlugin/lib/vendor/phing/tasks/ext/pearpackage/Fileset.php
@@ -194,7 +194,7 @@ class PEAR_PackageFileManager_Fileset {
      */
     function setDir($dir, $contents)
     {
-        while(list($one,$two) = each($contents)) {
+        foreach ($contents as $one => $two) {
             if (isset($dir[$one])) {
                 $dir[$one] = $this->setDir($dir[$one], $contents[$one]);
             } else {


### PR DESCRIPTION
Function each() is deprecated in PHP8.

This PR refactores the usages by replacing them with foreach structures.