### PR TITLE
php8: removed abstract static methods

### DIFF
--- a/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/builder/om/php5/PHP5PeerBuilder.php
+++ b/lib/plugins/sfPropelPlugin/lib/vendor/propel-generator/classes/propel/engine/builder/om/php5/PHP5PeerBuilder.php
@@ -1042,7 +1042,7 @@ abstract class ".$this->getClassname(). $extendingPeerClass . " {
 	 * @throws     PropelException Any exceptions caught during processing will be
 	 *		 rethrown wrapped into a PropelException.
 	 */
-	abstract public static function getOMClass();
+	public static function getOMClass() {};
 ";
 	}
 
@@ -1084,7 +1084,7 @@ abstract class ".$this->getClassname(). $extendingPeerClass . " {
 	 * This method must be overridden by the stub subclass, because
 	 * ".$this->getObjectClassname()." is declared abstract in the schema.
 	 */
-	abstract public static function getOMClass(\$withPrefix = true);
+	public static function getOMClass(\$withPrefix = true) {};
 ";
 	}
 


### PR DESCRIPTION
Abstract static methods are no longer supported.

This is a quick fix that works. It isn't worth it to go deeper on this propel thing.