### PR TITLE
allow silent logs of 404 errors

### DIFF
--- a/lib/exception/sfError404Exception.class.php
+++ b/lib/exception/sfError404Exception.class.php
@@ -41,7 +41,7 @@ class sfError404Exception extends sfException
     else
     {
       // log all exceptions in php log
-      if (!sfConfig::get('sf_test'))
+      if (!sfConfig::get('sf_test') && !sfConfig::get('sf_silent_404_logs'))
       {
         error_log($this->getMessage());
       }


### PR DESCRIPTION
Logs get flooded with 404 errors. It was a thing back in the 2000s but not anymore.

This (not breaking) change allows to silent those logs by optionally adding a new setting in `settings.yml`:

```
all:
  .settings:
     ...
     silent_404_logs: true

```