### PR TITLE
Fixed error for buggy function (method copied from FOS)

### DIFF
--- a/lib/cache/sfMemcacheCache.class.php
+++ b/lib/cache/sfMemcacheCache.class.php
@@ -201,16 +201,18 @@ class sfMemcacheCache extends sfCache
   /**
    * @see sfCache
    */
-  public function getMany($keys)
-  {
-    $values = array();
-    foreach ($this->memcache->get(array_map(function($k) { return "'.$this->getOption('prefix').'".$k; }, $keys)) as $key => $value)
+    public function getMany($keys)
     {
-      $values[str_replace($this->getOption('prefix'), '', $key)] = $value;
-    }
+        $values = [];
+        $prefix = $this->getOption('prefix');
+        $prefixed_keys = array_map(function ($k) use ($prefix) { return $prefix.$k; }, $keys);
 
-    return $values;
-  }
+        foreach ($this->memcache->get($prefixed_keys) as $key => $value) {
+            $values[str_replace($prefix, '', $key)] = $value;
+        }
+
+        return $values;
+    }
 
   /**
    * Gets metadata about a key in the cache.


### PR DESCRIPTION
Rector libray pointed out an error here.

At the beginning I thought it was a PHP 8 related error, but it turns out it's a bug and that method never worked properly.

I checked in FOS version and they corrected it too, I copied their solution.