### PR TITLE
Php 8.2 compatibility

### DIFF
--- a/lib/addon/sfData.class.php
+++ b/lib/addon/sfData.class.php
@@ -19,6 +19,7 @@
  */
 abstract class sfData
 {
+  public $maps = [];
   protected
     $deleteCurrentData = true,
     $object_references = array();

--- a/lib/addon/sfPager.class.php
+++ b/lib/addon/sfPager.class.php
@@ -528,8 +528,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Iterator
    */
-  #[\ReturnTypeWillChange]
-  public function current()
+  public function current(): mixed
   {
     if (!$this->isIteratorInitialized())
     {
@@ -544,8 +543,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Iterator
    */
-  #[\ReturnTypeWillChange]
-  public function key()
+  public function key(): mixed
   {
     if (!$this->isIteratorInitialized())
     {
@@ -596,8 +594,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Iterator
    */
-  #[\ReturnTypeWillChange]
-  public function valid()
+  public function valid(): bool
   {
     if (!$this->isIteratorInitialized())
     {
@@ -612,8 +609,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Countable
    */
-  #[\ReturnTypeWillChange]
-  public function count()
+  public function count(): int
   {
     return $this->getNbResults();
   }

--- a/lib/command/sfCommandApplication.class.php
+++ b/lib/command/sfCommandApplication.class.php
@@ -29,6 +29,7 @@ abstract class sfCommandApplication
     $currentTask    = null,
     $dispatcher     = null,
     $options        = array(),
+    $commandOptions = [],
     $formatter      = null;
 
   /**

--- a/lib/escaper/sfOutputEscaperArrayDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperArrayDecorator.class.php
@@ -41,8 +41,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
   /**
    * Reset the array to the beginning (as required for the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->value);
 
@@ -54,8 +53,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return string The key
    */
-  #[\ReturnTypeWillChange]
-  public function key()
+  public function key(): mixed
   {
     return key($this->value);
   }
@@ -68,8 +66,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return mixed The escaped value
    */
-  #[\ReturnTypeWillChange]
-  public function current()
+  public function current(): mixed
   {
     return sfOutputEscaper::escape($this->escapingMethod, current($this->value));
   }
@@ -77,8 +74,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
   /**
    * Moves to the next element (as required by the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function next()
+  public function next(): void
   {
     next($this->value);
 
@@ -94,8 +90,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return bool The validity of the current element; true if it is valid
    */
-  #[\ReturnTypeWillChange]
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }
@@ -107,8 +102,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return bool true if the offset isset; false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetExists($offset)
+  public function offsetExists($offset): bool
   {
     return isset($this->value[$offset]);
   }
@@ -120,8 +114,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return mixed The escaped value
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($offset)
+  public function offsetGet($offset): mixed
   {
     return sfOutputEscaper::escape($this->escapingMethod, $this->value[$offset]);
   }
@@ -138,8 +131,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @throws sfException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     throw new sfException('Cannot set values.');
   }
@@ -155,8 +147,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @throws sfException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
     throw new sfException('Cannot unset values.');
   }
@@ -166,8 +157,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return int The size of the array
    */
-  #[\ReturnTypeWillChange]
-  public function count()
+  public function count(): int
   {
     return count($this->value);
   }

--- a/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
@@ -67,8 +67,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return mixed The escaped value
    */
-  #[\ReturnTypeWillChange]
-  public function current()
+  public function current(): mixed
   {
     return sfOutputEscaper::escape($this->escapingMethod, $this->iterator->current());
   }
@@ -78,8 +77,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return string Iterator key
    */
-  #[\ReturnTypeWillChange]
-  public function key()
+  public function key(): mixed
   {
     return $this->iterator->key();
   }
@@ -99,8 +97,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return bool true if the current element is valid; false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function valid()
+  public function valid(): bool
   {
     return $this->iterator->valid();
   }
@@ -112,8 +109,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return bool true if the offset isset; false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetExists($offset)
+  public function offsetExists($offset): bool
   {
     return isset($this->value[$offset]);
   }
@@ -125,8 +121,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return mixed The escaped value
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($offset)
+  public function offsetGet($offset): mixed
   {
     return sfOutputEscaper::escape($this->escapingMethod, $this->value[$offset]);
   }
@@ -143,8 +138,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @throws sfException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     throw new sfException('Cannot set values.');
   }
@@ -160,8 +154,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @throws sfException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
     throw new sfException('Cannot unset values.');
   }

--- a/lib/escaper/sfOutputEscaperObjectDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperObjectDecorator.class.php
@@ -115,8 +115,7 @@ class sfOutputEscaperObjectDecorator extends sfOutputEscaperGetterDecorator impl
    *
    * @return int The size of the object
    */
-  #[\ReturnTypeWillChange]
-  public function count()
+  public function count(): int
   {
     return count($this->value);
   }

--- a/lib/event_dispatcher/sfEvent.php
+++ b/lib/event_dispatcher/sfEvent.php
@@ -117,8 +117,7 @@ class sfEvent implements ArrayAccess
    *
    * @return Boolean true if the parameter exists, false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return array_key_exists($name, $this->parameters);
   }
@@ -130,8 +129,7 @@ class sfEvent implements ArrayAccess
    *
    * @return mixed  The parameter value
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     if (!array_key_exists($name, $this->parameters))
     {
@@ -147,8 +145,7 @@ class sfEvent implements ArrayAccess
    * @param string  $name   The parameter name
    * @param mixed   $value  The parameter value 
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($name, $value)
+  public function offsetSet($name, $value): void
   {
     $this->parameters[$name] = $value;
   }
@@ -158,8 +155,7 @@ class sfEvent implements ArrayAccess
    *
    * @param string $name    The parameter name
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($name)
+  public function offsetUnset($name): void
   {
     unset($this->parameters[$name]);
   }

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -1035,8 +1035,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return Boolean true if the widget exists, false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return isset($this->widgetSchema[$name]);
   }
@@ -1048,8 +1047,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return sfFormField   A form field instance
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     if (!isset($this->formFields[$name]))
     {
@@ -1087,8 +1085,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @throws <b>LogicException</b>
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     throw new LogicException('Cannot update form fields.');
   }
@@ -1100,8 +1097,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @param string $offset The field name
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
     unset(
       $this->widgetSchema[$offset],
@@ -1165,8 +1161,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
   /**
    * Resets the field names array to the beginning (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function rewind()
+  public function rewind(): void
   {
     $this->fieldNames = $this->widgetSchema->getPositions();
 
@@ -1179,8 +1174,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return string The key
    */
-  #[\ReturnTypeWillChange]
-  public function key()
+  public function key(): mixed
   {
     return current($this->fieldNames);
   }
@@ -1190,8 +1184,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return mixed The escaped value
    */
-  #[\ReturnTypeWillChange]
-  public function current()
+  public function current(): mixed
   {
     return $this[current($this->fieldNames)];
   }
@@ -1199,8 +1192,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
   /**
    * Moves to the next form field (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function next()
+  public function next(): void
   {
     next($this->fieldNames);
     --$this->count;
@@ -1211,8 +1203,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return boolean The validity of the current element; true if it is valid
    */
-  #[\ReturnTypeWillChange]
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }
@@ -1222,8 +1213,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return integer The number of embedded form fields
    */
-  #[\ReturnTypeWillChange]
-  public function count()
+  public function count(): int
   {
     return count($this->getFormFieldSchema());
   }

--- a/lib/form/sfFormFieldSchema.class.php
+++ b/lib/form/sfFormFieldSchema.class.php
@@ -91,8 +91,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return Boolean true if the widget exists, false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return isset($this->widget[$name]);
   }
@@ -104,8 +103,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return sfFormField A form field instance
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     if (!isset($this->fields[$name]))
     {
@@ -144,8 +142,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @throws LogicException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     throw new LogicException('Cannot update form fields (read-only).');
   }
@@ -157,8 +154,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @throws LogicException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
     throw new LogicException('Cannot remove form fields (read-only).');
   }
@@ -166,8 +162,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
   /**
    * Resets the field names array to the beginning (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->fieldNames);
     $this->count = count($this->fieldNames);
@@ -178,8 +173,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return string The key
    */
-  #[\ReturnTypeWillChange]
-  public function key()
+  public function key(): mixed
   {
     return current($this->fieldNames);
   }
@@ -189,8 +183,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return mixed The escaped value
    */
-  #[\ReturnTypeWillChange]
-  public function current()
+  public function current(): mixed
   {
     return $this[current($this->fieldNames)];
   }
@@ -198,8 +191,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
   /**
    * Moves to the next form field (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function next()
+  public function next(): void
   {
     next($this->fieldNames);
     --$this->count;
@@ -210,8 +202,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return boolean The validity of the current element; true if it is valid
    */
-  #[\ReturnTypeWillChange]
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }
@@ -221,8 +212,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return integer The number of embedded form fields
    */
-  #[\ReturnTypeWillChange]
-  public function count()
+  public function count(): int
   {
     return count($this->fieldNames);
   }

--- a/lib/i18n/sfMessageSource_File.class.php
+++ b/lib/i18n/sfMessageSource_File.class.php
@@ -30,6 +30,8 @@
  */
 abstract class sfMessageSource_File extends sfMessageSource
 {
+  protected $dataExt;
+
   /**
    * Separator between culture name and source.
    * @var string

--- a/lib/plugin/sfPearRest11.class.php
+++ b/lib/plugin/sfPearRest11.class.php
@@ -20,6 +20,8 @@ require_once 'PEAR/REST/11.php';
  */
 class sfPearRest11 extends PEAR_REST_11
 {
+  public $_rest;
+
   /**
    * @see PEAR_REST_11
    */

--- a/lib/plugins/sfDoctrinePlugin/lib/database/sfDoctrineConnectionListener.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/database/sfDoctrineConnectionListener.class.php
@@ -20,6 +20,9 @@
  */
 class sfDoctrineConnectionListener extends Doctrine_EventListener
 {
+  public $connection;
+  public $encoding;
+
   public function __construct($connection, $encoding)
   {
     $this->connection = $connection;

--- a/lib/plugins/sfDoctrinePlugin/lib/generator/sfDoctrineFormGenerator.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/generator/sfDoctrineFormGenerator.class.php
@@ -22,6 +22,13 @@
  */
 class sfDoctrineFormGenerator extends sfGenerator
 {
+  public $params;
+  /**
+   * @var \Doctrine_Table
+   */
+  public $table;
+  public $modelName;
+
   /**
    * Array of all the loaded models
    *

--- a/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineGenerateModuleTask.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineGenerateModuleTask.class.php
@@ -20,6 +20,8 @@ require_once(dirname(__FILE__).'/sfDoctrineBaseTask.class.php');
  */
 class sfDoctrineGenerateModuleTask extends sfDoctrineBaseTask
 {
+  protected $constants;
+
   /**
    * @see sfTask
    */

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Access.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Access.php
@@ -100,8 +100,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $offset
      * @return  boolean Whether or not this object contains $offset
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->contains($offset);
     }
@@ -113,8 +112,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $offset
      * @return  mixed
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         // array notation with no index was causing 'undefined variable: $offset' notices in php7,
         // for example:
@@ -133,8 +131,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $value
      * @return  void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if ( ! isset($offset)) {
             $this->add($value);

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Adapter/Statement/Oracle.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Adapter/Statement/Oracle.php
@@ -239,7 +239,7 @@ class Doctrine_Adapter_Statement_Oracle implements Doctrine_Adapter_Statement_In
 
         if ($oci_error) {
             //store the error
-            $this->oci_errors[] = $oci_error;
+            $this->ociErrors[] = $oci_error;
         } else if (count($this->ociErrors) > 0) {
             $oci_error = $this->ociErrors[count($this->ociErrors)-1];
         }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Cli/AnsiColorFormatter.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Cli/AnsiColorFormatter.php
@@ -129,7 +129,7 @@ class Doctrine_Cli_AnsiColorFormatter extends Doctrine_Cli_Formatter
     public function excerpt($text, $size = null)
     {
         if ( ! $size) {
-            $size = $this->size;
+            $size = $this->_size;
         }
 
         if (strlen($text) < $size) {

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Cli/AnsiColorFormatter.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Cli/AnsiColorFormatter.php
@@ -115,7 +115,7 @@ class Doctrine_Cli_AnsiColorFormatter extends Doctrine_Cli_Formatter
     {
         $width = 9 + strlen($this->format('', 'INFO'));
 
-        return sprintf(">> %-${width}s %s", $this->format($section, 'INFO'), $this->excerpt($text, $size));
+        return sprintf(">> %-" . $width . "s %s", $this->format($section, 'INFO'), $this->excerpt($text, $size));
     }
 
     /**

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Collection.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Collection.php
@@ -420,8 +420,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return integer
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->data);
     }
@@ -1025,8 +1024,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return Iterator
      */
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         $data = $this->data;
         return new ArrayIterator($data);

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Collection/Iterator.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Collection/Iterator.php
@@ -74,7 +74,7 @@ abstract class Doctrine_Collection_Iterator implements Iterator
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->index = 0;
         $i = $this->index;
@@ -88,7 +88,7 @@ abstract class Doctrine_Collection_Iterator implements Iterator
      *
      * @return integer
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->key;
     }
@@ -98,7 +98,7 @@ abstract class Doctrine_Collection_Iterator implements Iterator
      *
      * @return Doctrine_Record
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->collection->get($this->key);
     }
@@ -108,7 +108,7 @@ abstract class Doctrine_Collection_Iterator implements Iterator
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->index++;
         $i = $this->index;

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Collection/OnDemand.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Collection/OnDemand.php
@@ -64,7 +64,7 @@ class Doctrine_Collection_OnDemand implements Iterator
         }
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->index = 0;
         $this->_stmt->closeCursor();
@@ -73,24 +73,24 @@ class Doctrine_Collection_OnDemand implements Iterator
         $this->_hydrateCurrent();
     }
 
-    public function key()
+    public function key(): mixed
     {
         return $this->index;
     }
 
-    public function current()
+    public function current(): mixed
     {
         return $this->_current;
     }
 
-    public function next()
+    public function next(): void
     {
         $this->_current = null;
         $this->index++;
         $this->_hydrateCurrent();
     }
 
-    public function valid()
+    public function valid(): bool
     {
         if ( ! is_null($this->_current) && $this->_current !== false) {
             return true;

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Connection.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Connection.php
@@ -1151,8 +1151,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      *
      * @return ArrayIterator        SPL ArrayIterator object
      */
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->tables);
     }
@@ -1162,8 +1161,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      *
      * @return integer
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return $this->_count;
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Connection/Profiler.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Connection/Profiler.php
@@ -134,8 +134,7 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
      *
      * @return ArrayIterator
      */
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->events);
     }
@@ -145,8 +144,7 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
      * 
      * @return integer
      */
-    #[\ReturnTypeWillChange]
-    public function count() 
+    public function count(): int
     {
         return count($this->events);
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Formatter.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Formatter.php
@@ -32,6 +32,9 @@
  */
 class Doctrine_Formatter extends Doctrine_Connection_Module
 {
+    public $string_quoting;
+    public $wildcards;
+
     /**
      * Quotes pattern (% and _) characters in a string)
      *

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Hydrator/Graph.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Hydrator/Graph.php
@@ -35,6 +35,7 @@
  */
 abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
 {
+    public $_rootAlias;
     protected $_tables = array();
 
     /**

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/IntegrityMapper.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/IntegrityMapper.php
@@ -32,6 +32,8 @@
  */
 class Doctrine_IntegrityMapper 
 {
+    public $conn;
+
     /**
      * processDeleteIntegrity 
      * 

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Manager.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Manager.php
@@ -818,7 +818,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      */
     public function getConnectionDrivers()
     {
-        return $this->_connectionsDrivers;
+        return $this->_connectionDrivers;
     }
 
     /**

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Manager.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Manager.php
@@ -635,8 +635,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      *
      * @return integer
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->_connections);
     }
@@ -646,8 +645,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      *
      * @return ArrayIterator
      */
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->_connections);
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node.php
@@ -160,8 +160,7 @@ class Doctrine_Node implements IteratorAggregate
      * @param string $type                      type of iterator (Pre | Post | Level)
      * @param array $options                    options
      */
-    #[\ReturnTypeWillChange]
-    public function getIterator($type = null, $options = null)
+    public function getIterator($type = null, $options = null): Traversable
     {
         if ($type === null) {
             $type = (isset($this->iteratorType) ? $this->iteratorType : 'Pre');

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/MaterializedPath/LevelOrderIterator.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/MaterializedPath/LevelOrderIterator.php
@@ -41,27 +41,27 @@ class Doctrine_Node_MaterializedPath_LevelOrderIterator implements Iterator
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function valid()
+    public function valid(): bool
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function current()
+    public function current(): mixed
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function key()
+    public function key(): mixed
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function next()
+    public function next(): void
     {
         throw new Doctrine_Exception('Not yet implemented');
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/MaterializedPath/PostOrderIterator.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/MaterializedPath/PostOrderIterator.php
@@ -41,27 +41,27 @@ class Doctrine_Node_MaterializedPath_PostOrderIterator implements Iterator
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function valid()
+    public function valid(): bool
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function current()
+    public function current(): mixed
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function key()
+    public function key(): mixed
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function next()
+    public function next(): void
     {
         throw new Doctrine_Exception('Not yet implemented');
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/MaterializedPath/PreOrderIterator.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/MaterializedPath/PreOrderIterator.php
@@ -41,27 +41,27 @@ class Doctrine_Node_MaterializedPath_PreOrderIterator implements Iterator
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function valid()
+    public function valid(): bool
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function current()
+    public function current(): mixed
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function key()
+    public function key(): mixed
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function next()
+    public function next(): void
     {
         throw new Doctrine_Exception('Not yet implemented');
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/NestedSet/PreOrderIterator.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/NestedSet/PreOrderIterator.php
@@ -105,7 +105,7 @@ class Doctrine_Node_NestedSet_PreOrderIterator implements Iterator
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->index = -1;
         $this->key = null;
@@ -116,7 +116,7 @@ class Doctrine_Node_NestedSet_PreOrderIterator implements Iterator
      *
      * @return integer
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->key;
     }
@@ -126,7 +126,7 @@ class Doctrine_Node_NestedSet_PreOrderIterator implements Iterator
      *
      * @return Doctrine_Record
      */
-    public function current()
+    public function current(): mixed
     {
         $record = $this->collection->get($this->key);
         $record->getNode()->setLevel($this->level);
@@ -138,6 +138,7 @@ class Doctrine_Node_NestedSet_PreOrderIterator implements Iterator
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         while ($current = $this->advanceIndex()) {
@@ -154,7 +155,7 @@ class Doctrine_Node_NestedSet_PreOrderIterator implements Iterator
     /**
      * @return boolean                          whether or not the iteration will continue
      */
-    public function valid()
+    public function valid(): bool
     {
         return ($this->index < $this->count);
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/NestedSet/PreOrderIterator.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/NestedSet/PreOrderIterator.php
@@ -67,6 +67,11 @@ class Doctrine_Node_NestedSet_PreOrderIterator implements Iterator
      */
     protected $count;
 
+    public $maxLevel;
+    public $options;
+    public $level;
+    public $prevLeft;
+
     public function __construct($record, $opts)
     {
         $componentName = $record->getTable()->getComponentName();

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Query.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Query.php
@@ -2133,8 +2133,7 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
      * @param array $params        an array of prepared statement parameters
      * @return integer             the count of this query
      */
-    #[\ReturnTypeWillChange]
-    public function count($params = array())
+    public function count($params = array()): int
     {
         $q = $this->getCountSqlQuery();
         $params = $this->getCountQueryParams($params);

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Query/Abstract.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Query/Abstract.php
@@ -270,6 +270,10 @@ abstract class Doctrine_Query_Abstract
      */
     protected $disableLimitSubquery = false;
 
+    protected $_pendingJoinConditions = [];
+
+    protected $_parsers = [];
+
     /**
      * Constructor.
      *

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/RawSql.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/RawSql.php
@@ -59,7 +59,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
 
     protected function clear()
     {
-        $this->_preQuery = false;
+        $this->_preQueried = false;
         $this->_pendingJoinConditions = array();
     }
 

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Record.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Record.php
@@ -1866,8 +1866,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      *
      * @return integer          the number of columns in this record
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->_data);
     }
@@ -2164,8 +2163,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * implements IteratorAggregate interface
      * @return Doctrine_Record_Iterator     iterator through data
      */
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): Doctrine_Record_Iterator
     {
         return new Doctrine_Record_Iterator($this);
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Record/Iterator.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Record/Iterator.php
@@ -68,8 +68,7 @@ class Doctrine_Record_Iterator extends ArrayIterator
      *
      * @return mixed
      */
-    #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
         $value = parent::current();
 

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Relation.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Relation.php
@@ -169,14 +169,12 @@ abstract class Doctrine_Relation implements ArrayAccess
         return $this->definition['equal'];
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->definition[$offset]);
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (isset($this->definition[$offset])) {
             return $this->definition[$offset];
@@ -185,16 +183,14 @@ abstract class Doctrine_Relation implements ArrayAccess
         return null;
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (isset($this->definition[$offset])) {
             $this->definition[$offset] = $value;
         }
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->definition[$offset] = false;
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Sequence.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Sequence.php
@@ -34,6 +34,11 @@
 class Doctrine_Sequence extends Doctrine_Connection_Module
 {
     /**
+     * @var string[]
+     */
+    public $warnings;
+
+    /**
      * Returns the next free id of a sequence
      *
      * @param string $seqName   name of the sequence

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Table.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Table.php
@@ -1951,8 +1951,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
      *
      * @return integer number of records in the table
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return $this->createQuery()->count();
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Table/Repository.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Table/Repository.php
@@ -102,8 +102,7 @@ class Doctrine_Table_Repository implements Countable, IteratorAggregate
      * Doctrine_Registry implements interface Countable
      * @return integer                      the number of records this registry has
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->registry);
     }
@@ -139,8 +138,7 @@ class Doctrine_Table_Repository implements Countable, IteratorAggregate
      * getIterator
      * @return ArrayIterator
      */
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->registry);
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Task/BuildAll.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Task/BuildAll.php
@@ -36,6 +36,7 @@ class Doctrine_Task_BuildAll extends Doctrine_Task
            $requiredArguments    =   array(),
            $optionalArguments    =   array();
     
+    public $createDb;
     protected $models,
               $tables;
     

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Task/BuildAllLoad.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Task/BuildAllLoad.php
@@ -32,6 +32,8 @@
  */
 class Doctrine_Task_BuildAllLoad extends Doctrine_Task
 {
+    public $buildAll;
+    public $loadData;
     public $description          =   'Calls build-all, and load-data',
            $requiredArguments    =   array(),
            $optionalArguments    =   array();

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Task/BuildAllReload.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Task/BuildAllReload.php
@@ -32,6 +32,8 @@
  */
 class Doctrine_Task_BuildAllReload extends Doctrine_Task
 {
+    public $rebuildDb;
+    public $loadData;
     public $description          =   'Calls rebuild-db and load-data',
            $requiredArguments    =   array(),
            $optionalArguments    =   array();

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Task/RebuildDb.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Task/RebuildDb.php
@@ -32,6 +32,9 @@
  */
 class Doctrine_Task_RebuildDb extends Doctrine_Task
 {
+    public $dropDb;
+    public $createDb;
+    public $createTables;
     public $description          =   'Drops and re-creates databases',
            $requiredArguments    =   array(),
            $optionalArguments    =   array();

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Validator.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Validator.php
@@ -33,6 +33,7 @@
  */
 class Doctrine_Validator extends Doctrine_Locator_Injectable
 {
+    public $stack;
     /**
      * @var array $validators           an array of validator objects
      */

--- a/lib/request/sfRequest.class.php
+++ b/lib/request/sfRequest.class.php
@@ -150,8 +150,7 @@ abstract class sfRequest implements ArrayAccess
    *
    * @return Boolean true if the request parameter exists, false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return $this->hasParameter($name);
   }
@@ -163,8 +162,7 @@ abstract class sfRequest implements ArrayAccess
    *
    * @return mixed The request parameter if exists, null otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     return $this->getParameter($name, false);
   }
@@ -175,8 +173,7 @@ abstract class sfRequest implements ArrayAccess
    * @param string $offset The parameter name
    * @param string $value The parameter value
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     $this->setParameter($offset, $value);
   }
@@ -186,8 +183,7 @@ abstract class sfRequest implements ArrayAccess
    *
    * @param string $offset The parameter name
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
     $this->getParameterHolder()->remove($offset);
   }

--- a/lib/routing/sfRoute.class.php
+++ b/lib/routing/sfRoute.class.php
@@ -18,6 +18,8 @@
  */
 class sfRoute
 {
+  public $firstOptional;
+  public $segments;
   protected
     $isBound           = false,
     $context           = null,

--- a/lib/routing/sfRouteCollection.class.php
+++ b/lib/routing/sfRouteCollection.class.php
@@ -61,8 +61,7 @@ class sfRouteCollection implements Iterator
   /**
    * Reset the error array to the beginning (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->routes);
 
@@ -74,8 +73,7 @@ class sfRouteCollection implements Iterator
    *
    * @return string The key
    */
-  #[\ReturnTypeWillChange]
-  public function key()
+  public function key(): string
   {
     return key($this->routes);
   }
@@ -85,8 +83,7 @@ class sfRouteCollection implements Iterator
    *
    * @return mixed The escaped value
    */
-  #[\ReturnTypeWillChange]
-  public function current()
+  public function current(): mixed
   {
     return current($this->routes);
   }
@@ -94,8 +91,7 @@ class sfRouteCollection implements Iterator
   /**
    * Moves to the next route (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function next()
+  public function next(): void
   {
     next($this->routes);
 
@@ -107,8 +103,7 @@ class sfRouteCollection implements Iterator
    *
    * @return boolean The validity of the current route; true if it is valid
    */
-  #[\ReturnTypeWillChange]
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }

--- a/lib/task/help/sfHelpTask.class.php
+++ b/lib/task/help/sfHelpTask.class.php
@@ -96,7 +96,7 @@ EOF;
       foreach ($task->getArguments() as $argument)
       {
         $default = null !== $argument->getDefault() && (!is_array($argument->getDefault()) || count($argument->getDefault())) ? $this->formatter->format(sprintf(' (default: %s)', is_array($argument->getDefault()) ? str_replace("\n", '', print_r($argument->getDefault(), true)): $argument->getDefault()), 'COMMENT') : '';
-        $messages[] = sprintf(" %-${max}s %s%s", $this->formatter->format($argument->getName(), 'INFO'), $argument->getHelp(), $default);
+        $messages[] = sprintf(" %-" . $max . "s %s%s", $this->formatter->format($argument->getName(), 'INFO'), $argument->getHelp(), $default);
       }
 
       $messages[] = '';

--- a/lib/task/help/sfListTask.class.php
+++ b/lib/task/help/sfListTask.class.php
@@ -120,7 +120,7 @@ EOF;
 
       $aliases = $task->getAliases() ? $this->formatter->format(' ('.implode(', ', $task->getAliases()).')', 'COMMENT') : '';
 
-      $messages[] = sprintf("  %-${width}s %s%s", $this->formatter->format(':'.$task->getName(), 'INFO'), $task->getBriefDescription(), $aliases);
+      $messages[] = sprintf("  %-".$width."s %s%s", $this->formatter->format(':'.$task->getName(), 'INFO'), $task->getBriefDescription(), $aliases);
     }
 
     $this->log($messages);

--- a/lib/task/sfBaseTask.class.php
+++ b/lib/task/sfBaseTask.class.php
@@ -18,6 +18,8 @@
  */
 abstract class sfBaseTask extends sfCommandApplicationTask
 {
+  public $filesystem;
+  public $tokens;
   protected
     $configuration = null,
     $pluginManager = null;

--- a/lib/task/sfCommandApplicationTask.class.php
+++ b/lib/task/sfCommandApplicationTask.class.php
@@ -19,6 +19,7 @@
 abstract class sfCommandApplicationTask extends sfTask
 {
   protected
+    $configuration = null,
     $mailer = null,
     $routing = null,
     $commandApplication = null;

--- a/lib/user/sfUser.class.php
+++ b/lib/user/sfUser.class.php
@@ -221,8 +221,7 @@ class sfUser implements ArrayAccess
    *
    * @return Boolean true if the user attribute exists, false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return $this->hasAttribute($name);
   }
@@ -234,8 +233,7 @@ class sfUser implements ArrayAccess
    *
    * @return mixed The user attribute if exists, null otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     return $this->getAttribute($name, false);
   }
@@ -246,8 +244,7 @@ class sfUser implements ArrayAccess
    * @param string $offset The parameter name
    * @param string $value The parameter value
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     $this->setAttribute($offset, $value);
   }
@@ -257,8 +254,7 @@ class sfUser implements ArrayAccess
    *
    * @param string $offset The parameter name
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
     $this->getAttributeHolder()->remove($offset);
   }

--- a/lib/util/sfBrowser.class.php
+++ b/lib/util/sfBrowser.class.php
@@ -18,6 +18,7 @@
  */
 class sfBrowser extends sfBrowserBase
 {
+  public $rawConfiguration;
   protected
     $listeners        = array(),
     $context          = null,

--- a/lib/util/sfContext.class.php
+++ b/lib/util/sfContext.class.php
@@ -457,8 +457,7 @@ class sfContext implements ArrayAccess
    *
    * @return Boolean true if the context object exists, false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return $this->has($name);
   }
@@ -470,8 +469,7 @@ class sfContext implements ArrayAccess
    *
    * @return mixed The context object if exists, null otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     return $this->get($name);
   }
@@ -482,8 +480,7 @@ class sfContext implements ArrayAccess
    * @param string $offset The parameter name
    * @param string $value The parameter value
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     $this->set($offset, $value);
   }
@@ -493,8 +490,7 @@ class sfContext implements ArrayAccess
    *
    * @param string $offset The parameter name
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
     unset($this->factories[$offset]);
   }

--- a/lib/util/sfDomCssSelector.class.php
+++ b/lib/util/sfDomCssSelector.class.php
@@ -563,7 +563,7 @@ class sfDomCssSelector implements Countable, Iterator
   /**
    * Reset the array to the beginning (as required for the Iterator interface).
    */
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->nodes);
 
@@ -575,7 +575,7 @@ class sfDomCssSelector implements Countable, Iterator
    *
    * @return string The key
    */
-  public function key()
+  public function key(): mixed
   {
     return key($this->nodes);
   }
@@ -585,7 +585,7 @@ class sfDomCssSelector implements Countable, Iterator
    *
    * @return mixed The escaped value
    */
-  public function current()
+  public function current(): mixed
   {
     return current($this->nodes);
   }
@@ -593,7 +593,7 @@ class sfDomCssSelector implements Countable, Iterator
   /**
    * Moves to the next element (as required by the Iterator interface).
    */
-  public function next()
+  public function next(): void
   {
     next($this->nodes);
 
@@ -609,7 +609,7 @@ class sfDomCssSelector implements Countable, Iterator
    *
    * @return bool The validity of the current element; true if it is valid
    */
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }
@@ -619,7 +619,7 @@ class sfDomCssSelector implements Countable, Iterator
    *
    * @param integer The number of matching nodes
    */
-  public function count()
+  public function count(): int
   {
     return count($this->nodes);
   }

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -194,8 +194,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return int The number of array
    */
-  #[\ReturnTypeWillChange]
-  public function count()
+  public function count(): int
   {
     return count($this->errors);
   }
@@ -203,8 +202,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
   /**
    * Reset the error array to the beginning (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->errors);
 
@@ -216,8 +214,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return string The key
    */
-  #[\ReturnTypeWillChange]
-  public function key()
+  public function key(): string
   {
     return key($this->errors);
   }
@@ -227,8 +224,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return mixed The escaped value
    */
-  #[\ReturnTypeWillChange]
-  public function current()
+  public function current(): mixed
   {
     return current($this->errors);
   }
@@ -236,8 +232,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
   /**
    * Moves to the next error (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function next()
+  public function next(): void
   {
     next($this->errors);
 
@@ -249,8 +244,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return boolean The validity of the current element; true if it is valid
    */
-  #[\ReturnTypeWillChange]
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }
@@ -262,8 +256,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return bool true if the error exists, false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return isset($this->errors[$name]);
   }
@@ -275,8 +268,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return sfValidatorError A sfValidatorError instance
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     return isset($this->errors[$name]) ? $this->errors[$name] : null;
   }
@@ -289,8 +281,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @throws LogicException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     throw new LogicException('Unable update an error.');
   }
@@ -300,8 +291,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @param string $offset  (ignored)
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
   }
 

--- a/lib/validator/sfValidatorFromDescription.class.php
+++ b/lib/validator/sfValidatorFromDescription.class.php
@@ -330,6 +330,7 @@ class sfValidatorFDTokenFilter
 
 class sfValidatorFDTokenOperator
 {
+  public $arguments;
   protected
     $class,
     $operator,

--- a/lib/validator/sfValidatorSchema.class.php
+++ b/lib/validator/sfValidatorSchema.class.php
@@ -301,8 +301,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
    *
    * @return bool true if the schema has a field with the given name, false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return isset($this->fields[$name]);
   }
@@ -314,8 +313,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
    *
    * @return sfValidatorBase The sfValidatorBase instance associated with the given name, null if it does not exist
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     return isset($this->fields[$name]) ? $this->fields[$name] : null;
   }
@@ -326,8 +324,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
    * @param string          $name       The field name
    * @param sfValidatorBase $validator  An sfValidatorBase instance
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($name, $validator)
+  public function offsetSet($name, $validator): void
   {
     if (!$validator instanceof sfValidatorBase)
     {
@@ -342,8 +339,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
    *
    * @param string $name
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($name)
+  public function offsetUnset($name): void
   {
     unset($this->fields[$name]);
   }

--- a/lib/vendor/swiftmailer/classes/Swift/Attachment.php
+++ b/lib/vendor/swiftmailer/classes/Swift/Attachment.php
@@ -28,8 +28,11 @@ class Swift_Attachment extends Swift_Mime_Attachment
   public function __construct($data = null, $filename = null,
     $contentType = null)
   {
-    call_user_func_array(
-      array($this, 'Swift_Mime_Attachment::__construct'),
+    $constructor = new ReflectionMethod(
+      'Swift_Mime_Attachment', '__construct'
+    );
+    $constructor->invokeArgs(
+      $this,
       Swift_DependencyContainer::getInstance()
         ->createDependenciesFor('mime.attachment')
       );

--- a/lib/vendor/swiftmailer/classes/Swift/EmbeddedFile.php
+++ b/lib/vendor/swiftmailer/classes/Swift/EmbeddedFile.php
@@ -28,8 +28,11 @@ class Swift_EmbeddedFile extends Swift_Mime_EmbeddedFile
   public function __construct($data = null, $filename = null,
     $contentType = null)
   {
-    call_user_func_array(
-      array($this, 'Swift_Mime_EmbeddedFile::__construct'),
+    $constructor = new ReflectionMethod(
+      'Swift_Mime_EmbeddedFile', '__construct'
+    );
+    $constructor->invokeArgs(
+      $this,
       Swift_DependencyContainer::getInstance()
         ->createDependenciesFor('mime.embeddedfile')
       );

--- a/lib/vendor/swiftmailer/classes/Swift/FailoverTransport.php
+++ b/lib/vendor/swiftmailer/classes/Swift/FailoverTransport.php
@@ -24,8 +24,11 @@ class Swift_FailoverTransport extends Swift_Transport_FailoverTransport
    */
   public function __construct($transports = array())
   {
-    call_user_func_array(
-      array($this, 'Swift_Transport_FailoverTransport::__construct'),
+    $constructor = new ReflectionMethod(
+      'Swift_Transport_FailoverTransport', '__construct'
+    );
+    $constructor->invokeArgs(
+      $this,
       Swift_DependencyContainer::getInstance()
         ->createDependenciesFor('transport.failover')
       );

--- a/lib/vendor/swiftmailer/classes/Swift/LoadBalancedTransport.php
+++ b/lib/vendor/swiftmailer/classes/Swift/LoadBalancedTransport.php
@@ -24,8 +24,11 @@ class Swift_LoadBalancedTransport extends Swift_Transport_LoadBalancedTransport
    */
   public function __construct($transports = array())
   {
-    call_user_func_array(
-      array($this, 'Swift_Transport_LoadBalancedTransport::__construct'),
+    $constructor = new ReflectionMethod(
+      'Swift_Transport_LoadBalancedTransport', '__construct'
+    );
+    $constructor->invokeArgs(
+      $this,
       Swift_DependencyContainer::getInstance()
         ->createDependenciesFor('transport.loadbalanced')
       );

--- a/lib/vendor/swiftmailer/classes/Swift/MailTransport.php
+++ b/lib/vendor/swiftmailer/classes/Swift/MailTransport.php
@@ -24,8 +24,11 @@ class Swift_MailTransport extends Swift_Transport_MailTransport
    */
   public function __construct($extraParams = '-f%s')
   {
-    call_user_func_array(
-      array($this, 'Swift_Transport_MailTransport::__construct'),
+    $constructor = new ReflectionMethod(
+      'Swift_Transport_MailTransport', '__construct'
+    );
+    $constructor->invokeArgs(
+      $this,
       Swift_DependencyContainer::getInstance()
         ->createDependenciesFor('transport.mail')
       );

--- a/lib/vendor/swiftmailer/classes/Swift/Message.php
+++ b/lib/vendor/swiftmailer/classes/Swift/Message.php
@@ -29,8 +29,11 @@ class Swift_Message extends Swift_Mime_SimpleMessage
   public function __construct($subject = null, $body = null,
     $contentType = null, $charset = null)
   {
-    call_user_func_array(
-      array($this, 'Swift_Mime_SimpleMessage::__construct'),
+    $constructor = new ReflectionMethod(
+      'Swift_Mime_SimpleMessage', '__construct'
+    );
+    $constructor->invokeArgs(
+      $this,
       Swift_DependencyContainer::getInstance()
         ->createDependenciesFor('mime.message')
       );

--- a/lib/vendor/swiftmailer/classes/Swift/MimePart.php
+++ b/lib/vendor/swiftmailer/classes/Swift/MimePart.php
@@ -28,8 +28,11 @@ class Swift_MimePart extends Swift_Mime_MimePart
   public function __construct($body = null, $contentType = null,
     $charset = null)
   {
-    call_user_func_array(
-      array($this, 'Swift_Mime_MimePart::__construct'),
+    $constructor = new ReflectionMethod(
+      'Swift_Mime_MimePart', '__construct'
+    );
+    $constructor->invokeArgs(
+      $this,
       Swift_DependencyContainer::getInstance()
         ->createDependenciesFor('mime.part')
       );

--- a/lib/vendor/swiftmailer/classes/Swift/NullTransport.php
+++ b/lib/vendor/swiftmailer/classes/Swift/NullTransport.php
@@ -20,11 +20,14 @@ class Swift_NullTransport extends Swift_Transport_NullTransport
    */
   public function __construct()
   {
-    call_user_func_array(
-      array($this, 'Swift_Transport_NullTransport::__construct'),
+    $constructor = new ReflectionMethod(
+      'Swift_Transport_NullTransport', '__construct'
+    );
+    $constructor->invokeArgs(
+      $this,
       Swift_DependencyContainer::getInstance()
         ->createDependenciesFor('transport.null')
-    );
+      );
   }
   
   /**

--- a/lib/vendor/swiftmailer/classes/Swift/SendmailTransport.php
+++ b/lib/vendor/swiftmailer/classes/Swift/SendmailTransport.php
@@ -24,8 +24,11 @@ class Swift_SendmailTransport extends Swift_Transport_SendmailTransport
    */
   public function __construct($command = '/usr/sbin/sendmail -bs')
   {
-    call_user_func_array(
-      array($this, 'Swift_Transport_SendmailTransport::__construct'),
+    $constructor = new ReflectionMethod(
+      'Swift_Transport_SendmailTransport', '__construct'
+    );
+    $constructor->invokeArgs(
+      $this,
       Swift_DependencyContainer::getInstance()
         ->createDependenciesFor('transport.sendmail')
       );

--- a/lib/vendor/swiftmailer/classes/Swift/SmtpTransport.php
+++ b/lib/vendor/swiftmailer/classes/Swift/SmtpTransport.php
@@ -27,8 +27,11 @@ class Swift_SmtpTransport extends Swift_Transport_EsmtpTransport
   public function __construct($host = 'localhost', $port = 25,
     $security = null)
   {
-    call_user_func_array(
-      array($this, 'Swift_Transport_EsmtpTransport::__construct'),
+    $constructor = new ReflectionMethod(
+      'Swift_Transport_EsmtpTransport', '__construct'
+    );
+    $constructor->invokeArgs(
+      $this,
       Swift_DependencyContainer::getInstance()
         ->createDependenciesFor('transport.smtp')
       );

--- a/lib/vendor/swiftmailer/classes/Swift/SpoolTransport.php
+++ b/lib/vendor/swiftmailer/classes/Swift/SpoolTransport.php
@@ -26,10 +26,10 @@ class Swift_SpoolTransport extends Swift_Transport_SpoolTransport
 
     $arguments[] = $spool;
 
-    call_user_func_array(
-      array($this, 'Swift_Transport_SpoolTransport::__construct'),
-      $arguments
+    $constructor = new ReflectionMethod(
+      'Swift_Transport_SpoolTransport', '__construct'
     );
+    $constructor->invokeArgs($this, $arguments);
   }
   
   /**

--- a/lib/view/sfViewCacheManager.class.php
+++ b/lib/view/sfViewCacheManager.class.php
@@ -22,6 +22,7 @@
  */
 class sfViewCacheManager
 {
+  public $options;
   protected
     $cache       = null,
     $cacheConfig = array(),

--- a/lib/widget/sfWidgetFormSchema.class.php
+++ b/lib/widget/sfWidgetFormSchema.class.php
@@ -656,8 +656,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
    *
    * @return bool true if the schema has a field with the given name, false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return isset($this->fields[$name]);
   }
@@ -669,8 +668,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
    *
    * @return sfWidget|null The sfWidget instance associated with the given name, null if it does not exist
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     return isset($this->fields[$name]) ? $this->fields[$name] : null;
   }
@@ -683,8 +681,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
    *
    * @throws InvalidArgumentException when the field is not instance of sfWidget
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($name, $widget)
+  public function offsetSet($name, $widget): void
   {
     if (!$widget instanceof sfWidget)
     {
@@ -710,8 +707,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
    *
    * @param string $name field name
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($name)
+  public function offsetUnset($name): void
   {
     unset($this->fields[$name]);
     if (false !== $position = array_search((string) $name, $this->positions))

--- a/lib/widget/sfWidgetFormSchemaDecorator.class.php
+++ b/lib/widget/sfWidgetFormSchemaDecorator.class.php
@@ -319,7 +319,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
   /**
    * @see sfWidgetFormSchema
    */
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return isset($this->widget[$name]);
   }
@@ -327,7 +327,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
   /**
    * @see sfWidgetFormSchema
    */
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     return $this->widget[$name];
   }
@@ -335,7 +335,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
   /**
    * @see sfWidgetFormSchema
    */
-  public function offsetSet($name, $widget)
+  public function offsetSet($name, $widget): void
   {
     $this->widget[$name] = $widget;
   }
@@ -343,7 +343,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
   /**
    * @see sfWidgetFormSchema
    */
-  public function offsetUnset($name)
+  public function offsetUnset($name): void
   {
     unset($this->widget[$name]);
   }


### PR DESCRIPTION
This PR fixes deprecation notices for PHP 8.2 (*). 

Every commit addresses a different type (I went back and forth creating new branches so I could group them properly and make it easier to review). So feel free to cherry-pick the commits instead of merging the whole branch.

(*) Except for this commit [added correct return types where possible](https://github.com/welante/symfony1-php5.5/commit/75dee46801adf25fe36a8768038cd697f537befc), which adds the return types that we marked as  `#[ReturnTypeWillChange]`, which adds `mixed` return type and breaks BC with PHP 7.4