### PR TITLE
php7to8: fixed warning

### DIFF
--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Query/Having.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Query/Having.php
@@ -78,7 +78,7 @@ class Doctrine_Query_Having extends Doctrine_Query_Condition
      * @param mixed $value
      * @return string
      */
-    final private function _parseAliases($value)
+    private function _parseAliases($value)
     {
         if ( ! is_numeric($value)) {
             $a = explode('.', $value);


### PR DESCRIPTION
`final private` is a redundancy that makes no sense: private can't be extended anyway, so why declaring it final.

Prior to PHP8 it was resolved silently but as of PHP8 it shows a warning. This PR fixes it.