### PR TITLE
php7to8: fixed deprecations on Iterator extending classes

### DIFF
--- a/lib/addon/sfPager.class.php
+++ b/lib/addon/sfPager.class.php
@@ -596,8 +596,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Iterator
    */
-  #[\ReturnTypeWillChange]
-  public function valid()
+  public function valid(): bool
   {
     if (!$this->isIteratorInitialized())
     {
@@ -612,8 +611,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Countable
    */
-  #[\ReturnTypeWillChange]
-  public function count()
+  public function count(): int
   {
     return $this->getNbResults();
   }

--- a/lib/escaper/sfOutputEscaperArrayDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperArrayDecorator.class.php
@@ -41,8 +41,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
   /**
    * Reset the array to the beginning (as required for the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->value);
 
@@ -77,8 +76,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
   /**
    * Moves to the next element (as required by the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function next()
+  public function next(): void
   {
     next($this->value);
 
@@ -94,8 +92,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return bool The validity of the current element; true if it is valid
    */
-  #[\ReturnTypeWillChange]
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }
@@ -107,8 +104,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return bool true if the offset isset; false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetExists($offset)
+  public function offsetExists($offset): bool
   {
     return isset($this->value[$offset]);
   }
@@ -138,8 +134,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @throws sfException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     throw new sfException('Cannot set values.');
   }
@@ -155,8 +150,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @throws sfException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
     throw new sfException('Cannot unset values.');
   }
@@ -166,8 +160,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return int The size of the array
    */
-  #[\ReturnTypeWillChange]
-  public function count()
+  public function count(): int
   {
     return count($this->value);
   }

--- a/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
@@ -99,8 +99,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return bool true if the current element is valid; false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function valid()
+  public function valid(): bool
   {
     return $this->iterator->valid();
   }
@@ -112,8 +111,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return bool true if the offset isset; false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetExists($offset)
+  public function offsetExists($offset): bool
   {
     return isset($this->value[$offset]);
   }
@@ -143,8 +141,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @throws sfException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     throw new sfException('Cannot set values.');
   }
@@ -160,8 +157,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @throws sfException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
     throw new sfException('Cannot unset values.');
   }

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -1165,8 +1165,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
   /**
    * Resets the field names array to the beginning (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function rewind()
+  public function rewind(): void
   {
     $this->fieldNames = $this->widgetSchema->getPositions();
 
@@ -1199,8 +1198,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
   /**
    * Moves to the next form field (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function next()
+  public function next(): void
   {
     next($this->fieldNames);
     --$this->count;
@@ -1211,8 +1209,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return boolean The validity of the current element; true if it is valid
    */
-  #[\ReturnTypeWillChange]
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }
@@ -1222,8 +1219,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return integer The number of embedded form fields
    */
-  #[\ReturnTypeWillChange]
-  public function count()
+  public function count(): int
   {
     return count($this->getFormFieldSchema());
   }

--- a/lib/form/sfFormFieldSchema.class.php
+++ b/lib/form/sfFormFieldSchema.class.php
@@ -157,8 +157,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @throws LogicException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
     throw new LogicException('Cannot remove form fields (read-only).');
   }
@@ -166,8 +165,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
   /**
    * Resets the field names array to the beginning (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->fieldNames);
     $this->count = count($this->fieldNames);
@@ -198,8 +196,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
   /**
    * Moves to the next form field (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function next()
+  public function next(): void
   {
     next($this->fieldNames);
     --$this->count;
@@ -210,8 +207,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return boolean The validity of the current element; true if it is valid
    */
-  #[\ReturnTypeWillChange]
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }
@@ -221,8 +217,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return integer The number of embedded form fields
    */
-  #[\ReturnTypeWillChange]
-  public function count()
+  public function count(): int
   {
     return count($this->fieldNames);
   }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Collection/Iterator.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Collection/Iterator.php
@@ -74,6 +74,7 @@ abstract class Doctrine_Collection_Iterator implements Iterator
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->index = 0;
@@ -88,6 +89,7 @@ abstract class Doctrine_Collection_Iterator implements Iterator
      *
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->key;
@@ -98,7 +100,7 @@ abstract class Doctrine_Collection_Iterator implements Iterator
      *
      * @return Doctrine_Record
      */
-    public function current()
+    public function current(): Doctrine_Record
     {
         return $this->collection->get($this->key);
     }
@@ -108,7 +110,7 @@ abstract class Doctrine_Collection_Iterator implements Iterator
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->index++;
         $i = $this->index;

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Collection/OnDemand.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Collection/OnDemand.php
@@ -64,7 +64,7 @@ class Doctrine_Collection_OnDemand implements Iterator
         }
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->index = 0;
         $this->_stmt->closeCursor();
@@ -73,16 +73,19 @@ class Doctrine_Collection_OnDemand implements Iterator
         $this->_hydrateCurrent();
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->index;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->_current;
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->_current = null;
@@ -90,7 +93,7 @@ class Doctrine_Collection_OnDemand implements Iterator
         $this->_hydrateCurrent();
     }
 
-    public function valid()
+    public function valid(): bool
     {
         if ( ! is_null($this->_current) && $this->_current !== false) {
             return true;

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/MaterializedPath/LevelOrderIterator.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/MaterializedPath/LevelOrderIterator.php
@@ -41,27 +41,29 @@ class Doctrine_Node_MaterializedPath_LevelOrderIterator implements Iterator
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function valid()
+    public function valid(): bool
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function next()
+    public function next(): void
     {
         throw new Doctrine_Exception('Not yet implemented');
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/MaterializedPath/PostOrderIterator.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/MaterializedPath/PostOrderIterator.php
@@ -41,27 +41,29 @@ class Doctrine_Node_MaterializedPath_PostOrderIterator implements Iterator
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function valid()
+    public function valid(): bool
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function next()
+    public function next(): void
     {
         throw new Doctrine_Exception('Not yet implemented');
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/MaterializedPath/PreOrderIterator.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/MaterializedPath/PreOrderIterator.php
@@ -41,27 +41,29 @@ class Doctrine_Node_MaterializedPath_PreOrderIterator implements Iterator
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function valid()
+    public function valid(): bool
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         throw new Doctrine_Exception('Not yet implemented');
     }
 
-    public function next()
+    public function next(): void
     {
         throw new Doctrine_Exception('Not yet implemented');
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/NestedSet/PreOrderIterator.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Node/NestedSet/PreOrderIterator.php
@@ -100,7 +100,7 @@ class Doctrine_Node_NestedSet_PreOrderIterator implements Iterator
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->index = -1;
         $this->key = null;
@@ -111,6 +111,7 @@ class Doctrine_Node_NestedSet_PreOrderIterator implements Iterator
      *
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->key;
@@ -121,7 +122,7 @@ class Doctrine_Node_NestedSet_PreOrderIterator implements Iterator
      *
      * @return Doctrine_Record
      */
-    public function current()
+    public function current(): Doctrine_Record
     {
         $record = $this->collection->get($this->key);
         $record->getNode()->setLevel($this->level);
@@ -133,6 +134,7 @@ class Doctrine_Node_NestedSet_PreOrderIterator implements Iterator
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         while ($current = $this->advanceIndex()) {
@@ -149,7 +151,7 @@ class Doctrine_Node_NestedSet_PreOrderIterator implements Iterator
     /**
      * @return boolean                          whether or not the iteration will continue
      */
-    public function valid()
+    public function valid(): bool
     {
         return ($this->index < $this->count);
     }

--- a/lib/routing/sfRouteCollection.class.php
+++ b/lib/routing/sfRouteCollection.class.php
@@ -61,8 +61,7 @@ class sfRouteCollection implements Iterator
   /**
    * Reset the error array to the beginning (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->routes);
 
@@ -94,8 +93,7 @@ class sfRouteCollection implements Iterator
   /**
    * Moves to the next route (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function next()
+  public function next(): void
   {
     next($this->routes);
 
@@ -107,8 +105,7 @@ class sfRouteCollection implements Iterator
    *
    * @return boolean The validity of the current route; true if it is valid
    */
-  #[\ReturnTypeWillChange]
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }

--- a/lib/util/sfDomCssSelector.class.php
+++ b/lib/util/sfDomCssSelector.class.php
@@ -563,7 +563,7 @@ class sfDomCssSelector implements Countable, Iterator
   /**
    * Reset the array to the beginning (as required for the Iterator interface).
    */
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->nodes);
 
@@ -575,6 +575,7 @@ class sfDomCssSelector implements Countable, Iterator
    *
    * @return string The key
    */
+  #[\ReturnTypeWillChange]
   public function key()
   {
     return key($this->nodes);
@@ -585,6 +586,7 @@ class sfDomCssSelector implements Countable, Iterator
    *
    * @return mixed The escaped value
    */
+  #[\ReturnTypeWillChange]
   public function current()
   {
     return current($this->nodes);
@@ -593,7 +595,7 @@ class sfDomCssSelector implements Countable, Iterator
   /**
    * Moves to the next element (as required by the Iterator interface).
    */
-  public function next()
+  public function next(): void
   {
     next($this->nodes);
 
@@ -609,7 +611,7 @@ class sfDomCssSelector implements Countable, Iterator
    *
    * @return bool The validity of the current element; true if it is valid
    */
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }
@@ -619,7 +621,7 @@ class sfDomCssSelector implements Countable, Iterator
    *
    * @param integer The number of matching nodes
    */
-  public function count()
+  public function count(): int
   {
     return count($this->nodes);
   }

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -194,8 +194,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return int The number of array
    */
-  #[\ReturnTypeWillChange]
-  public function count()
+  public function count(): int
   {
     return count($this->errors);
   }
@@ -203,8 +202,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
   /**
    * Reset the error array to the beginning (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->errors);
 
@@ -236,8 +234,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
   /**
    * Moves to the next error (implements the Iterator interface).
    */
-  #[\ReturnTypeWillChange]
-  public function next()
+  public function next(): void
   {
     next($this->errors);
 
@@ -250,7 +247,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    * @return boolean The validity of the current element; true if it is valid
    */
   #[\ReturnTypeWillChange]
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }
@@ -262,8 +259,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return bool true if the error exists, false otherwise
    */
-  #[\ReturnTypeWillChange]
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return isset($this->errors[$name]);
   }
@@ -289,8 +285,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @throws LogicException
    */
-  #[\ReturnTypeWillChange]
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     throw new LogicException('Unable update an error.');
   }
@@ -300,8 +295,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @param string $offset  (ignored)
    */
-  #[\ReturnTypeWillChange]
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
   }
 


### PR DESCRIPTION
- Added missing return types when possible (or `#[returnTypeWillChange]` when not) to Iterators
- Replaced existing `#[returnTypeWillChange]` with the correct return type when possible, on Iterators