### PR TITLE
php7to8: ensure BC with php7 on serialized objects for smooth migration

### DIFF
--- a/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Record.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine/Doctrine/Record.php
@@ -31,7 +31,7 @@
  * @since       1.0
  * @version     $Revision: 7673 $
  */
-abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Countable, IteratorAggregate
+abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Countable, IteratorAggregate, Serializable
 {
     /**
      * STATE CONSTANTS
@@ -788,6 +788,32 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
                 }
                 break;
         }
+    }
+
+    /**
+     * Serializable interface implementation for BC with PHP7-
+     *
+     * @return string
+     */
+    public function serialize()
+    {
+        $vars = $this->__serialize();
+
+        return serialize($vars);
+    }
+
+    /**
+     * Serializable interface implementation for BC with PHP7-
+     *
+     * @param string $serialized                Doctrine_Record as serialized string
+     * @throws Doctrine_Record_Exception        if the cleanData operation fails somehow
+     * @return void
+     */
+    public function unserialize($serialized)
+    {
+        $array = unserialize($serialized);
+
+        $this->__unserialize($array);
     }
 
     public function __serialize(): array


### PR DESCRIPTION
At the moment of the migration there can be serialized Doctrine Records that are persisted in session data.

As we know, Serializable interface was deprecated in favor of __serialize() and __userialize(), and that comes also with a change in serialization format, which makes them uncompatible.

There's two options to handle this:
1) Force a session reset for all users
2) Maintain temporarily BC compatibility by keeping Serializable interface (it can be removed safely after some time when all data is migrated)